### PR TITLE
Enable HCP for AX3080-EVK and add eeprom/tpm75 to ax3000 SCM

### DIFF
--- a/arch/arm64/boot/dts/axiado/ax3000-scm3002-evk.dts
+++ b/arch/arm64/boot/dts/axiado/ax3000-scm3002-evk.dts
@@ -8,5 +8,25 @@
 
 / {
 	compatible = "axiado,ax3000-evk", "axiado,ax3000";
+
+	aliases {
+		i2c0 = &i3c0;
+		i2c1 = &i3c1;
+		i2c2 = &i3c2;
+		i2c3 = &i3c3;
+		i2c4 = &i3c4;
+		i2c5 = &i3c5;
+		i2c6 = &i3c6;
+		i2c7 = &i3c7;
+		i2c8 = &i3c8;
+		i2c9 = &i3c9;
+		i2c10 = &i3c10;
+		i2c11 = &i3c11;
+		i2c12 = &i3c12;
+		i2c13 = &i3c13;
+		i2c14 = &i3c14;
+		i2c15 = &i3c15;
+		i2c16 = &i3c16;
+	};
 };
 

--- a/arch/arm64/boot/dts/axiado/ax3000-scm3002.dtsi
+++ b/arch/arm64/boot/dts/axiado/ax3000-scm3002.dtsi
@@ -125,6 +125,19 @@
 
 &i3c7 {
 	status = "okay";
+
+	temp@48 {
+		compatible = "ti,tmp75c";
+		reg = <0x48 0x0 0x50>;
+	};
+	temp@49 {
+		compatible = "ti,tmp75c";
+		reg = <0x49 0x0 0x50>;
+	};
+	eeprom@50 {
+		compatible = "atmel,24c16";
+		reg = <0x50 0x0 0x50>;
+	};
 };
 
 &i3c8 {

--- a/arch/arm64/boot/dts/axiado/ax3000-scm3003-evk.dts
+++ b/arch/arm64/boot/dts/axiado/ax3000-scm3003-evk.dts
@@ -8,5 +8,25 @@
 
 / {
 	compatible = "axiado,ax3000-evk", "axiado,ax3000";
+
+	aliases {
+		i2c0 = &i3c0;
+		i2c1 = &i3c1;
+		i2c2 = &i3c2;
+		i2c3 = &i3c3;
+		i2c4 = &i3c4;
+		i2c5 = &i3c5;
+		i2c6 = &i3c6;
+		i2c7 = &i3c7;
+		i2c8 = &i3c8;
+		i2c9 = &i3c9;
+		i2c10 = &i3c10;
+		i2c11 = &i3c11;
+		i2c12 = &i3c12;
+		i2c13 = &i3c13;
+		i2c14 = &i3c14;
+		i2c15 = &i3c15;
+		i2c16 = &i3c16;
+	};
 };
 

--- a/arch/arm64/boot/dts/axiado/ax3000-scm3003.dtsi
+++ b/arch/arm64/boot/dts/axiado/ax3000-scm3003.dtsi
@@ -134,6 +134,15 @@
 
 &i3c7 {
 	status = "okay";
+
+	temp@48 {
+		compatible = "tmp75";
+		reg = <0x48 0x0 0x50>;
+	};
+	eeprom@50 {
+		compatible = "atmel,24c16";
+		reg = <0x50 0x0 0x50>;
+	};
 };
 
 &i3c8 {

--- a/arch/arm64/boot/dts/axiado/ax3080-evk.dts
+++ b/arch/arm64/boot/dts/axiado/ax3080-evk.dts
@@ -282,4 +282,66 @@
 	status = "okay";
 };
 
+&hcp {
+	status = "okay";
+};
+
+&mac0 {
+	phy-handle = <&phy0>;
+	swap-abcd;
+	status = "okay";
+};
+
+&mac1 {
+	phy-handle = <&phy1>;
+	status = "okay";
+};
+
+&mac2 {
+	phy-handle = <&phy2>;
+	status = "okay";
+};
+
+&mac3 {
+	phy-handle = <&phy3>;
+	status = "okay";
+};
+
+&mac4 {
+	phy-handle = <&phy4>;
+	status = "okay";
+};
+
+&mdio {
+	phy0: phy0@0 {
+		reg = <0>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		#thermal-sensor-cells = <0>;
+		status = "okay";
+	};
+	phy1: phy1@1 {
+		reg = <1>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+		#thermal-sensor-cells = <0>;
+		status = "okay";
+	};
+	phy2: phy2@2 {
+		reg = <2>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+		#thermal-sensor-cells = <0>;
+		status = "okay";
+	};
+	phy3: phy3@3 {
+		reg = <3>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+		#thermal-sensor-cells = <0>;
+		status = "okay";
+	};
+	phy4: phy4@4 {
+		reg = <4>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+		#thermal-sensor-cells = <0>;
+		status = "okay";
+	};
+};
 


### PR DESCRIPTION
Enable the HCP node and MACs, wire up PHY handles, and define the MDIO PHYs for the AX3080 EVK.