### PR TITLE
mctp: i2c: fix rx overflow handling and support per-device DT tuning

### DIFF
--- a/drivers/net/mctp/mctp-i2c.c
+++ b/drivers/net/mctp/mctp-i2c.c
@@ -22,6 +22,7 @@
 #include <linux/i2c.h>
 #include <linux/i2c-mux.h>
 #include <linux/if_arp.h>
+#include <linux/of.h>
 #include <net/mctp.h>
 #include <net/mctpdevice.h>
 
@@ -63,6 +64,7 @@ struct mctp_i2c_dev {
 	struct list_head list; /* For mctp_i2c_client.devs */
 
 	size_t rx_pos;
+	bool rx_overflow;
 	u8 rx_buffer[MCTP_I2C_BUFSZ];
 	struct completion rx_done;
 
@@ -80,6 +82,7 @@ struct mctp_i2c_dev {
 	int release_count;
 	/* Indicates that the netif is ready to receive incoming packets */
 	bool allow_rx;
+	bool flows_enabled;
 
 };
 
@@ -206,10 +209,12 @@ static void __mctp_i2c_device_select(struct mctp_i2c_client *mcli,
 				     struct mctp_i2c_dev *midev)
 {
 	assert_spin_locked(&mcli->sel_lock);
-	if (midev)
+	if (midev) {
 		dev_hold(midev->ndev);
-	if (mcli->sel)
+	}
+	if (mcli->sel) {
 		dev_put(mcli->sel->ndev);
+	}
 	mcli->sel = midev;
 }
 
@@ -252,8 +257,9 @@ static int mctp_i2c_slave_cb(struct i2c_client *client,
 		if (midev->rx_pos < MCTP_I2C_BUFSZ) {
 			midev->rx_buffer[midev->rx_pos] = *val;
 			midev->rx_pos++;
-		} else {
+		} else if (!midev->rx_overflow) {
 			midev->ndev->stats.rx_over_errors++;
+			midev->rx_overflow = true;
 		}
 
 		break;
@@ -261,9 +267,13 @@ static int mctp_i2c_slave_cb(struct i2c_client *client,
 		/* dest_slave as first byte */
 		midev->rx_buffer[0] = mcli->lladdr << 1;
 		midev->rx_pos = 1;
+		midev->rx_overflow = false;
 		break;
 	case I2C_SLAVE_STOP:
-		rc = mctp_i2c_recv(midev);
+		if (midev->rx_overflow)
+			rc = -EINVAL;
+		else
+			rc = mctp_i2c_recv(midev);
 		break;
 	default:
 		break;
@@ -496,7 +506,10 @@ static void mctp_i2c_xmit(struct mctp_i2c_dev *midev, struct sk_buff *skb)
 	u8 *pecp;
 	int rc;
 
-	fs = mctp_i2c_get_tx_flow_state(midev, skb);
+	if (midev->flows_enabled)
+		fs = mctp_i2c_get_tx_flow_state(midev, skb);
+	else
+		fs = MCTP_I2C_TX_FLOW_NONE;
 
 	hdr = (void *)skb_mac_header(skb);
 	/* Sanity check that packet contents matches skb length,
@@ -557,8 +570,6 @@ static void mctp_i2c_xmit(struct mctp_i2c_dev *midev, struct sk_buff *skb)
 	}
 
 	if (rc < 0) {
-		dev_warn_ratelimited(&midev->adapter->dev,
-				     "__i2c_transfer failed %d\n", rc);
 		stats->tx_errors++;
 	} else {
 		stats->tx_bytes += skb->len;
@@ -759,6 +770,7 @@ static struct mctp_i2c_dev *mctp_i2c_midev_init(struct net_device *dev,
 	midev->adapter = adap;
 	get_device(&mcli->client->dev);
 	midev->client = mcli;
+	midev->flows_enabled = true;
 	INIT_LIST_HEAD(&midev->list);
 	spin_lock_init(&midev->lock);
 	midev->i2c_lock_count = 0;
@@ -901,6 +913,18 @@ static int mctp_i2c_add_netdev(struct mctp_i2c_client *mcli,
 			"register netdev \"%s\" failed %d\n",
 			ndev->name, rc);
 		goto err;
+	}
+
+	if (adap->dev.of_node) {
+		u32 timeout_ms;
+
+		if (!of_property_read_u32(adap->dev.of_node,
+					  "mctp-timeout-ms", &timeout_ms))
+			mctp_dev_set_timeout(ndev, timeout_ms);
+
+		if (of_property_read_bool(adap->dev.of_node,
+					  "mctp-no-flows"))
+			midev->flows_enabled = false;
 	}
 
 	spin_lock_irqsave(&midev->lock, flags);
@@ -1100,6 +1124,39 @@ static struct notifier_block mctp_i2c_notifier = {
 	.notifier_call = mctp_i2c_notifier_call,
 };
 
+/* Netdevice notifier to re-attach ops after namespace change.
+ * When a netdev moves namespaces, NETDEV_UNREGISTER fires in the old ns
+ * which destroys the mctp_dev, then NETDEV_REGISTER fires in the new ns
+ * which creates a new mctp_dev but without the ops pointer.
+ */
+static int mctp_i2c_netdev_notify(struct notifier_block *nb,
+				  unsigned long event, void *ptr)
+{
+	struct net_device *dev = netdev_notifier_info_to_dev(ptr);
+	struct mctp_dev *mdev;
+
+	if (event != NETDEV_REGISTER)
+		return NOTIFY_DONE;
+
+	if (dev->netdev_ops != &mctp_i2c_ops)
+		return NOTIFY_DONE;
+
+	rcu_read_lock();
+	mdev = __mctp_dev_get(dev);
+	if (mdev) {
+		if (!mdev->ops)
+			mdev->ops = &mctp_i2c_mctp_ops;
+		mctp_dev_put(mdev);
+	}
+	rcu_read_unlock();
+
+	return NOTIFY_DONE;
+}
+
+static struct notifier_block mctp_i2c_netdev_nb = {
+	.notifier_call = mctp_i2c_netdev_notify,
+};
+
 static const struct i2c_device_id mctp_i2c_id[] = {
 	{ "mctp-i2c-interface" },
 	{}
@@ -1135,6 +1192,12 @@ static __init int mctp_i2c_mod_init(void)
 		i2c_del_driver(&mctp_i2c_driver);
 		return rc;
 	}
+	rc = register_netdevice_notifier(&mctp_i2c_netdev_nb);
+	if (rc < 0) {
+		bus_unregister_notifier(&i2c_bus_type, &mctp_i2c_notifier);
+		i2c_del_driver(&mctp_i2c_driver);
+		return rc;
+	}
 	return 0;
 }
 
@@ -1142,6 +1205,7 @@ static __exit void mctp_i2c_mod_exit(void)
 {
 	int rc;
 
+	unregister_netdevice_notifier(&mctp_i2c_netdev_nb);
 	rc = bus_unregister_notifier(&i2c_bus_type, &mctp_i2c_notifier);
 	if (rc < 0)
 		pr_warn("MCTP I2C could not unregister notifier, %d\n", rc);

--- a/include/net/mctp.h
+++ b/include/net/mctp.h
@@ -37,6 +37,7 @@ struct mctp_hdr {
 #define MCTP_HDR_TAG_MASK	GENMASK(2, 0)
 
 #define MCTP_INITIAL_DEFAULT_NET	1
+#define MCTP_DEFAULT_LIFETIME		(6 * CONFIG_HZ)
 
 static inline bool mctp_address_unicast(mctp_eid_t eid)
 {
@@ -295,7 +296,8 @@ void mctp_key_unref(struct mctp_sk_key *key);
 struct mctp_sk_key *mctp_alloc_local_tag(struct mctp_sock *msk,
 					 unsigned int netid,
 					 mctp_eid_t local, mctp_eid_t peer,
-					 bool manual, u8 *tagp);
+					 bool manual, u8 *tagp,
+					 unsigned long lifetime);
 
 /* routing <--> device interface */
 unsigned int mctp_default_net(struct net *net);

--- a/include/net/mctpdevice.h
+++ b/include/net/mctpdevice.h
@@ -31,6 +31,8 @@ struct mctp_dev {
 	size_t			num_addrs;
 	spinlock_t		addrs_lock;
 
+	unsigned long		key_lifetime;
+
 	struct rcu_head		rcu;
 };
 
@@ -54,5 +56,7 @@ void mctp_dev_put(struct mctp_dev *mdev);
 
 void mctp_dev_set_key(struct mctp_dev *dev, struct mctp_sk_key *key);
 void mctp_dev_release_key(struct mctp_dev *dev, struct mctp_sk_key *key);
+
+void mctp_dev_set_timeout(struct net_device *dev, unsigned int timeout_ms);
 
 #endif /* __NET_MCTPDEVICE_H */

--- a/net/mctp/af_mctp.c
+++ b/net/mctp/af_mctp.c
@@ -517,7 +517,8 @@ static int mctp_ioctl_alloctag(struct mctp_sock *msk, bool tagv2,
 		return -EINVAL;
 
 	key = mctp_alloc_local_tag(msk, ctl.net, MCTP_ADDR_ANY,
-				   ctl.peer_addr, true, &tag);
+				   ctl.peer_addr, true, &tag,
+				   MCTP_DEFAULT_LIFETIME);
 	if (IS_ERR(key))
 		return PTR_ERR(key);
 

--- a/net/mctp/device.c
+++ b/net/mctp/device.c
@@ -342,6 +342,7 @@ static struct mctp_dev *mctp_add_dev(struct net_device *dev)
 	spin_lock_init(&mdev->addrs_lock);
 
 	mdev->net = mctp_default_net(dev_net(dev));
+	mdev->key_lifetime = MCTP_DEFAULT_LIFETIME;
 
 	/* associate to net_device */
 	refcount_set(&mdev->refs, 1);
@@ -509,6 +510,20 @@ void mctp_unregister_netdev(struct net_device *dev)
 	unregister_netdev(dev);
 }
 EXPORT_SYMBOL_GPL(mctp_unregister_netdev);
+
+void mctp_dev_set_timeout(struct net_device *dev, unsigned int timeout_ms)
+{
+	struct mctp_dev *mdev;
+
+	rcu_read_lock();
+	mdev = __mctp_dev_get(dev);
+	if (mdev) {
+		mdev->key_lifetime = msecs_to_jiffies(timeout_ms);
+		mctp_dev_put(mdev);
+	}
+	rcu_read_unlock();
+}
+EXPORT_SYMBOL_GPL(mctp_dev_set_timeout);
 
 static struct rtnl_af_ops mctp_af_ops = {
 	.family = AF_MCTP,

--- a/net/mctp/neigh.c
+++ b/net/mctp/neigh.c
@@ -312,10 +312,14 @@ static int __net_init mctp_neigh_net_init(struct net *net)
 static void __net_exit mctp_neigh_net_exit(struct net *net)
 {
 	struct netns_mctp *ns = &net->mctp;
-	struct mctp_neigh *neigh;
+	struct mctp_neigh *neigh, *tmp;
 
-	list_for_each_entry(neigh, &ns->neighbours, list)
+	mutex_lock(&ns->neigh_lock);
+	list_for_each_entry_safe(neigh, tmp, &ns->neighbours, list) {
+		list_del_rcu(&neigh->list);
 		call_rcu(&neigh->rcu, __mctp_neigh_free);
+	}
+	mutex_unlock(&ns->neigh_lock);
 }
 
 /* net namespace implementation */

--- a/net/mctp/route.c
+++ b/net/mctp/route.c
@@ -29,7 +29,6 @@
 #include <trace/events/mctp.h>
 
 static const unsigned int mctp_message_maxlen = 64 * 1024;
-static const unsigned long mctp_key_lifetime = 6 * CONFIG_HZ;
 
 static void mctp_flow_prepare_output(struct sk_buff *skb, struct mctp_dev *dev);
 
@@ -262,7 +261,8 @@ void mctp_key_unref(struct mctp_sk_key *key)
 	kfree(key);
 }
 
-static int mctp_key_add(struct mctp_sk_key *key, struct mctp_sock *msk)
+static int mctp_key_add(struct mctp_sk_key *key, struct mctp_sock *msk,
+			unsigned long lifetime)
 {
 	struct net *net = sock_net(&msk->sk);
 	struct mctp_sk_key *tmp;
@@ -290,7 +290,7 @@ static int mctp_key_add(struct mctp_sk_key *key, struct mctp_sock *msk)
 
 	if (!rc) {
 		refcount_inc(&key->refs);
-		key->expiry = jiffies + mctp_key_lifetime;
+		key->expiry = jiffies + lifetime;
 		timer_reduce(&msk->key_expiry, key->expiry);
 
 		hlist_add_head(&key->hlist, &net->mctp.keys);
@@ -549,7 +549,7 @@ static int mctp_dst_input(struct mctp_dst *dst, struct sk_buff *skb)
 			 * no way to distinguish future packets, so all we
 			 * can do is drop.
 			 */
-			rc = mctp_key_add(key, msk);
+			rc = mctp_key_add(key, msk, dst->dev->key_lifetime);
 			if (!rc)
 				trace_mctp_key_acquire(key);
 
@@ -704,13 +704,13 @@ int mctp_default_net_set(struct net *net, unsigned int index)
 
 /* tag management */
 static void mctp_reserve_tag(struct net *net, struct mctp_sk_key *key,
-			     struct mctp_sock *msk)
+			     struct mctp_sock *msk, unsigned long lifetime)
 {
 	struct netns_mctp *mns = &net->mctp;
 
 	lockdep_assert_held(&mns->keys_lock);
 
-	key->expiry = jiffies + mctp_key_lifetime;
+	key->expiry = jiffies + lifetime;
 	timer_reduce(&msk->key_expiry, key->expiry);
 
 	/* we hold the net->key_lock here, allowing updates to both
@@ -727,7 +727,8 @@ static void mctp_reserve_tag(struct net *net, struct mctp_sk_key *key,
 struct mctp_sk_key *mctp_alloc_local_tag(struct mctp_sock *msk,
 					 unsigned int netid,
 					 mctp_eid_t local, mctp_eid_t peer,
-					 bool manual, u8 *tagp)
+					 bool manual, u8 *tagp,
+					 unsigned long lifetime)
 {
 	struct net *net = sock_net(&msk->sk);
 	struct netns_mctp *mns = &net->mctp;
@@ -791,7 +792,7 @@ struct mctp_sk_key *mctp_alloc_local_tag(struct mctp_sock *msk,
 
 	if (tagbits) {
 		key->tag = __ffs(tagbits);
-		mctp_reserve_tag(net, key, msk);
+		mctp_reserve_tag(net, key, msk, lifetime);
 		trace_mctp_key_acquire(key);
 
 		key->manual_alloc = manual;
@@ -1141,7 +1142,8 @@ int mctp_local_output(struct sock *sk, struct mctp_dst *dst,
 						       req_tag, &tag);
 		else
 			key = mctp_alloc_local_tag(msk, netid, saddr, daddr,
-						   false, &tag);
+						   false, &tag,
+						   dst->dev->key_lifetime);
 
 		if (IS_ERR(key)) {
 			rc = PTR_ERR(key);
@@ -1737,19 +1739,26 @@ static int __net_init mctp_routes_net_init(struct net *net)
 	return 0;
 }
 
-static void __net_exit mctp_routes_net_exit(struct net *net)
+/* mctp routes are otherwise only mutated under RTNL (see mctp_route_add(),
+ * mctp_route_remove() and mctp_route_remove_dev()); unlink them here too so
+ * a concurrent RCU lookup can't observe a route this net is tearing down.
+ */
+static void __net_exit mctp_routes_net_exit_rtnl(struct net *net,
+						 struct list_head *dev_kill_list)
 {
-	struct mctp_route *rt;
+	struct mctp_route *rt, *tmp;
 
-	rcu_read_lock();
-	list_for_each_entry_rcu(rt, &net->mctp.routes, list)
+	ASSERT_RTNL();
+
+	list_for_each_entry_safe(rt, tmp, &net->mctp.routes, list) {
+		list_del_rcu(&rt->list);
 		mctp_route_release(rt);
-	rcu_read_unlock();
+	}
 }
 
 static struct pernet_operations mctp_net_ops = {
 	.init = mctp_routes_net_init,
-	.exit = mctp_routes_net_exit,
+	.exit_rtnl = mctp_routes_net_exit_rtnl,
 };
 
 static const struct rtnl_msg_handler mctp_route_rtnl_msg_handlers[] = {

--- a/net/mctp/test/route-test.c
+++ b/net/mctp/test/route-test.c
@@ -473,7 +473,7 @@ static void mctp_test_route_input_sk_keys(struct kunit *test)
 	KUNIT_ASSERT_NOT_ERR_OR_NULL(test, key);
 
 	spin_lock_irqsave(&mns->keys_lock, flags);
-	mctp_reserve_tag(&init_net, key, msk);
+	mctp_reserve_tag(&init_net, key, msk, MCTP_DEFAULT_LIFETIME);
 	spin_unlock_irqrestore(&mns->keys_lock, flags);
 
 	/* create packet and route */
@@ -671,7 +671,7 @@ mctp_test_route_input_multiple_nets_key_init(struct kunit *test,
 
 	mns = &sock_net(t->sock->sk)->mctp;
 	spin_lock_irqsave(&mns->keys_lock, flags);
-	mctp_reserve_tag(&init_net, t->key, msk);
+	mctp_reserve_tag(&init_net, t->key, msk, MCTP_DEFAULT_LIFETIME);
 	spin_unlock_irqrestore(&mns->keys_lock, flags);
 
 	KUNIT_ASSERT_NOT_ERR_OR_NULL(test, t->key);


### PR DESCRIPTION
Port several MCTP fixes/enhancements from NVIDIA's linux.git, branch develop-6.18 (https://github.com/NVIDIA/linux.git):

- i2c: track rx_overflow explicitly so an overflowed message is rejected at I2C_SLAVE_STOP instead of being handed to mctp_i2c_recv() as a truncated-but-valid packet, and avoid incrementing rx_over_errors once per byte. commit dcd50bf78c77 ("mctp: i2c: count RX overflow once per packet")

- i2c: remove the dev_warn_ratelimited() on __i2c_transfer() failure; it floods the log during periodic MCTP endpoint polling and the failure is already tracked via tx_errors. commit 93c32c5ccbc7 ("net: mctp-i2c: remove noisy __i2c_transfer failure log")

- i2c: reattach mctp_dev ops via a netdevice notifier after a device moves network namespace, since NETDEV_UNREGISTER/NETDEV_REGISTER recreates mctp_dev without ops. commit 0b000f4ce315 ("net: mctp-i2c: re-attach MCTP ops after network namespace change")

- i2c: add "mctp-timeout-ms" and "mctp-no-flows" devicetree properties to override the per-device MCTP key lifetime and disable flow-control tracking respectively.

- core: make MCTP key lifetime a per-mctp_dev value (mdev->key_lifetime) instead of a single global constant, so it can be set via mctp_dev_set_timeout(). commit 96d774e7dc0d ("mctp: Add support for EAGAIN retries and per-device key lifetime") -- only the MCTP core and mctp-i2c DT parsing pieces are taken here; the i2c-ast2600 EAGAIN/EBUSY retry changes from that commit are not applicable to our i2c driver and are left out. commit f8e5761c13a3 (net: mctp: Fix mctp_dev_set_timeout() to use __mctp_dev_get()), a same-series fixup to the above.

- neigh: fix net exit to unlink entries under ns->neigh_lock with list_for_each_entry_safe/list_del_rcu instead of walking the list unprotected. commit b13fc976baab ("mctp: neigh: unlink entries on netns exit")

- route: unlink routes with list_del_rcu under RTNL before release, since routes are otherwise only ever mutated under RTNL and the old exit path left them on the list after releasing them. commit 9591ed8595a1 ("mctp: route: unlink routes during netns exit") -- adapted to use the .exit_rtnl pernet hook directly (mctp_routes_net_exit_rtnl) rather than upstream's .exit_batch_rtnl + wrapper, since a single-net exit_rtnl call is sufficient here.